### PR TITLE
feat: real prop translations for shorthand props

### DIFF
--- a/src/TamaguiTags.ts
+++ b/src/TamaguiTags.ts
@@ -1,0 +1,3 @@
+export const baseTag = (tag: string) => `tama-${tag}` as const;
+
+export const TAMAGUI_SHORTHAND_TAG = baseTag('shorthand');

--- a/src/getCompletions.ts
+++ b/src/getCompletions.ts
@@ -37,9 +37,10 @@ export const getCompletions = (
 
   logger(`calculating tamagui completions <$${position}@${fileName}>`);
 
-  const type = getTokenType(fileName, position, config, ctx);
+  const tokenType = getTokenType(fileName, position, config, ctx);
 
-  if (!type) return original;
+  if (!tokenType) return original;
+  const { type } = tokenType;
 
   logger(`token type <${type}>`);
 

--- a/src/handleTagEntry.ts
+++ b/src/handleTagEntry.ts
@@ -1,0 +1,15 @@
+import {
+  CompletionEntryDetails,
+  QuickInfo,
+  SymbolDisplayPart,
+} from 'typescript/lib/tsserverlibrary';
+
+import { baseTag } from './TamaguiTags';
+
+export const handleTagEntry = (
+  tag: { name: ReturnType<typeof baseTag>; text: SymbolDisplayPart[] },
+  obj: QuickInfo | CompletionEntryDetails
+) => {
+  obj.tags ??= [];
+  obj.tags.push(tag);
+};

--- a/src/mapPropToToken.ts
+++ b/src/mapPropToToken.ts
@@ -2,23 +2,39 @@ import { tokenCategories } from '@tamagui/helpers';
 
 import { ParsedConfig } from './readConfig';
 
+interface MapPropToTokenReturn {
+  type: Exclude<keyof ParsedConfig, 'shorthands' | 'themeColors'>;
+  shorthand?: string;
+  prop: string;
+  isShorthand: boolean;
+}
+
 /**
  * Maps a property or shorthand to a token category
  */
-export const mapPropToToken = (prop: string, config: ParsedConfig) => {
-  const realProp =
-    (config.shorthands[prop as keyof typeof config.shorthands] as
-      | string
-      | undefined) ?? prop;
+export const mapPropToToken = (
+  prop: string,
+  config: ParsedConfig
+): MapPropToTokenReturn => {
+  const shorthandMapped = config.shorthands[
+    prop as keyof typeof config.shorthands
+  ] as string | undefined;
+  const isShorthand = Boolean(shorthandMapped);
+  const realProp = shorthandMapped ?? prop;
 
   for (const [category, properties] of Object.entries(tokenCategories)) {
     if (realProp in properties) {
-      return category as Exclude<
-        keyof ParsedConfig,
-        'shorthands' | 'themeColors'
-      >;
+      return {
+        type: category as Exclude<
+          keyof ParsedConfig,
+          'shorthands' | 'themeColors'
+        >,
+        shorthand: isShorthand ? prop : undefined,
+        prop: realProp,
+        isShorthand,
+      };
     }
   }
 
-  return 'space';
+  return { type: 'space', shorthand: prop, prop: realProp, isShorthand };
 };

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -68,6 +68,10 @@ export const makeColorTokenDescription = (
   ]);
 };
 
+export const makeShorthandDescription = (shorthand: string, prop: string) => {
+  return `\`${shorthand}\` is short for \`${prop}\``;
+};
+
 const formatThemePrefix = (key: string) => {
   return key.replace(/([A-Za-z0-9]+)(?:_|$)/g, (_, key) => toPascal(key));
 };

--- a/src/readOptions.ts
+++ b/src/readOptions.ts
@@ -56,6 +56,7 @@ export const readOptions = ({ info, modules }: TSContextBase) => {
     completionFilters: {
       showColorTokens = true,
       showTrueTokens = true,
+      showShorthandConversion = true,
       custom: {
         themeColor: themeColorFilters = undefined,
         color: colorFilters = undefined,
@@ -72,6 +73,7 @@ export const readOptions = ({ info, modules }: TSContextBase) => {
     completionFilters?: {
       showColorTokens?: boolean;
       showTrueTokens?: boolean;
+      showShorthandConversion?: boolean;
       custom?: {
         themeColor?: string[];
         color?: string[];
@@ -100,6 +102,7 @@ export const readOptions = ({ info, modules }: TSContextBase) => {
     completionFilters: {
       showColorTokens,
       showTrueTokens,
+      showShorthandConversion,
       custom: createCustomTokenFilter({
         themeColor: themeColorFilters,
         color: colorFilters,


### PR DESCRIPTION
Added some functionality to show shorthand translations using `tag` versus `documentation` due to deduping issues.

<img width="502" alt="image" src="https://github.com/nderscore/tamagui-typescript-plugin/assets/88064187/4117c3d0-2972-4383-bf13-cd700809cba9">

<img width="776" alt="image" src="https://github.com/nderscore/tamagui-typescript-plugin/assets/88064187/14b5a266-8cc7-418b-b376-2c447b9ba11d">

