### PR TITLE
feat: Add variant summary functionality on JSX components

### DIFF
--- a/src/getQuickInfo.ts
+++ b/src/getQuickInfo.ts
@@ -6,6 +6,7 @@ import {
   makeShorthandDescription,
   makeThemeTokenDescription,
   makeTokenDescription,
+  makeVariantsSummary,
 } from './metadata';
 import { ParsedConfig } from './readConfig';
 import { PluginOptions } from './readOptions';
@@ -41,8 +42,13 @@ export const getQuickInfo = (
 
   if (!tokenResult) return original;
 
-  const [{ type, isShorthand, shorthand, prop }, entryName, textSpan] =
-    tokenResult;
+  const [
+    { type, isShorthand, shorthand, prop },
+    entryName,
+    textSpan,
+    originNode,
+    variantsType,
+  ] = tokenResult;
 
   logger(`Logging shorthand and prop ${shorthand} ${prop}`);
 
@@ -64,6 +70,17 @@ export const getQuickInfo = (
       makeShorthandDescription(shorthand, prop)
     );
     touched = true;
+  }
+
+  if (variantsType && originNode) {
+    logger(`Inserting variant docs`);
+    const variantDocs = makeVariantsSummary(
+      variantsType,
+      originNode,
+      ctx.typeChecker
+    );
+    logger(variantDocs);
+    safeInsertDocs(result, 'variantDocs', variantDocs);
   }
 
   let foundThemeColor = false;

--- a/src/getVariantsType.ts
+++ b/src/getVariantsType.ts
@@ -1,0 +1,20 @@
+import ts from 'typescript/lib/tsserverlibrary';
+
+import { TSContext } from './types';
+
+export const getVariantsType = (
+  type: ts.Type,
+  node: ts.Node,
+  ctx: TSContext
+) => {
+  const TVariantPropsSymbol = type.getProperties().find((symb) => {
+    return symb.escapedName === '___variantProps';
+  });
+
+  if (!TVariantPropsSymbol) {
+    ctx.logger(`Could not find variant props`);
+    return;
+  }
+
+  return ctx.typeChecker.getTypeOfSymbolAtLocation(TVariantPropsSymbol, node);
+};

--- a/src/metadata.ts
+++ b/src/metadata.ts
@@ -1,4 +1,5 @@
 import color from 'color';
+import ts from 'typescript/lib/tsserverlibrary';
 
 import { PluginOptions } from './readOptions';
 import { toPascal } from './utils';
@@ -112,4 +113,32 @@ export const makeThemeTokenDescription = (
   }
 
   return makeTable(table);
+};
+
+export const makeVariantsSummary = (
+  type: ts.Type,
+  node: ts.Node,
+  typeChecker: ts.TypeChecker
+) => {
+  const variantsSummary = type.getProperties().map((symbol) => {
+    const variantType = typeChecker.getTypeOfSymbolAtLocation(symbol, node);
+
+    const variantName = symbol.escapedName;
+    const variantTypeString = typeChecker.typeToString(variantType, node);
+    const variantComment = ts
+      .displayPartsToString(symbol.getDocumentationComment(typeChecker))
+      .trim();
+    const variantSourceFiles = symbol.declarations
+      ?.map((d) => d.getSourceFile())
+      ?.map((file) => file.fileName);
+
+    const parsedTypeLink =
+      variantSourceFiles && variantSourceFiles.length
+        ? `([${variantTypeString}](file://${variantSourceFiles[0]}))`
+        : `(${variantTypeString})`;
+
+    return `**${variantName}** ${parsedTypeLink}\n\n${variantComment}\n\n---\n`;
+  });
+
+  return ['## Variants\n', ...variantsSummary].join('\n');
 };


### PR DESCRIPTION
Adds summarization for tamagui variants on components with hyperlinking to the variant definition
![image](https://github.com/nderscore/tamagui-typescript-plugin/assets/88064187/23ebc138-55e3-4bd6-afcf-23751309f08e)
